### PR TITLE
Restyle app with synthwave neon theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#0a0028" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;600&display=swap" rel="stylesheet" />
     <title>Croatian Phrase Coach</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -213,21 +213,32 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen" style={{ background: '#fafafa', color: '#111' }}>
+    <div className="app">
+      <section className="hero">
+        <div className="sun" />
+        <svg className="pyramid" viewBox="0 0 160 120">
+          <polygon points="80,0 0,120 160,120" />
+          <line x1="80" y1="0" x2="80" y2="120" />
+          <line x1="0" y1="120" x2="80" y2="60" />
+          <line x1="160" y1="120" x2="80" y2="60" />
+        </svg>
+        <div className="grid" />
+        <div className="hero-text">
+          <h1>Croatian Phrase Coach 🇭🇷</h1>
+          <p>Flashcards • Quiz • Spaced Repetition • TTS • Offline</p>
+        </div>
+      </section>
+
       <div className="max-w-5xl" style={{ margin: '0 auto', padding: '1rem 1.5rem' }}>
-        <header style={{ display: 'flex', gap: '12px', alignItems: 'flex-end', justifyContent: 'space-between', flexWrap: 'wrap' }}>
-          <div>
-            <h1 style={{ fontSize: '1.8rem', fontWeight: 800 }}>Croatian Phrase Coach 🇭🇷</h1>
-            <p style={{ fontSize: '0.9rem', color: '#666' }}>Flashcards • Quiz • Spaced Repetition • TTS • Offline</p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-            <button onClick={() => setMode("flashcards")} className={btn(mode === "flashcards")}>Flashcards</button>
-            <button onClick={() => setMode("quiz")} className={btn(mode === "quiz")}>Quiz</button>
-            <button onClick={() => setMode("manage")} className={btn(mode === "manage")}>Manage</button>
-          </div>
+        <header className="nav">
+          <button onClick={() => setMode("flashcards")} className={btn(mode === "flashcards")}>Flashcards</button>
+          <button onClick={() => setMode("quiz")} className={btn(mode === "quiz")}>Quiz</button>
+          <button onClick={() => setMode("manage")} className={btn(mode === "manage")}>Manage</button>
         </header>
 
-        <div style={{ marginTop: '12px', display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '8px' }}>
+        <hr className="divider" />
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '8px' }}>
           <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search Croatian or English" style={inp()} />
           <select value={cat} onChange={e => setCat(e.target.value)} style={inp()}>
             {["All", ...Array.from(new Set(cards.map(c => c.cat)))].map(c => <option key={c} value={c}>{c}</option>)}
@@ -237,9 +248,11 @@ export default function App() {
           </div>
         </div>
 
-        <div style={{ marginTop: '6px', fontSize: '0.9rem', color: '#666', display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
-          <span>Total: <b>{cards.filter(c => (cat === "All" || c.cat === cat)).length}</b></span>
-          <span>Due now: <b>{cards.filter(c => (c.srs?.due ?? 0) <= now()).length}</b></span>
+        <hr className="divider" />
+
+        <div style={{ fontSize: '0.8rem', display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+          <span>Total: <b style={{ color: 'var(--neon-yellow)' }}>{cards.filter(c => (cat === "All" || c.cat === cat)).length}</b></span>
+          <span>Due now: <b style={{ color: 'var(--neon-yellow)' }}>{cards.filter(c => (c.srs?.due ?? 0) <= now()).length}</b></span>
         </div>
 
         {mode === "flashcards" && (
@@ -286,24 +299,24 @@ function FlashcardStudy({ card, front, showAnswer, onFlip, onGrade, speak }) {
   const backText = front === "hr" ? card.en : card.hr;
   return (
     <div style={{ marginTop: '16px' }}>
-      <div style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: 16, padding: 16, boxShadow: '0 1px 2px rgba(0,0,0,0.03)' }}>
+      <div className="panel">
         <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <div style={{ fontSize: '1.6rem', fontWeight: 700, lineHeight: 1.2 }}>{frontText}</div>
+            <div style={{ fontSize: '1.6rem', fontWeight: 700, lineHeight: 1.2, color: 'var(--neon-yellow)' }}>{frontText}</div>
             <button onClick={() => speak(card.hr)} style={buttonBase({ padding: '4px 8px' })}>🔊</button>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ fontSize: 12, color: '#666' }}>{card.cat}</span>
+            <span style={{ fontSize: 12, color: 'var(--neon-pink)' }}>{card.cat}</span>
           </div>
         </div>
 
-        {card.note && <p style={{ marginTop: 8, fontSize: 14, color: '#666' }}>{card.note}</p>}
+        {card.note && <p style={{ marginTop: 8, fontSize: 14, color: 'var(--neon-blue)' }}>{card.note}</p>}
 
         <div style={{ marginTop: 16 }}>
           {!showAnswer ? (
             <button onClick={onFlip} style={buttonBase({ width: '100%' })}>Show answer</button>
           ) : (
-            <div style={{ background: '#fafafa', border: '1px solid #eaeaea', borderRadius: 12, padding: 12, fontSize: 18 }}>
+            <div style={{ background: 'rgba(0,0,0,0.2)', border: '2px solid var(--neon-blue)', borderRadius: 12, padding: 12, fontSize: 18, color: 'var(--neon-yellow)' }}>
               {backText}
             </div>
           )}
@@ -311,7 +324,7 @@ function FlashcardStudy({ card, front, showAnswer, onFlip, onGrade, speak }) {
 
         <div style={{ marginTop: 16, display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 8 }}>
           {["Again","Hard","Okay","Good","Easy"].map((label, i) => (
-            <button key={label} style={gradeBtn(i)} onClick={() => onGrade(i+1)}>{label}</button>
+            <button key={label} className="grade-btn" onClick={() => onGrade(i+1)}>{label}</button>
           ))}
         </div>
       </div>
@@ -334,9 +347,9 @@ function Quiz({ pool, idx, setIdx, choices, front, speak }) {
   const opts = choices.length ? choices : [target, ...pool.filter(c => c.id !== target.id).slice(0,3)];
 
   return (
-    <div style={{ marginTop: 16, background: '#fff', border: '1px solid #e5e5e5', borderRadius: 16, padding: 16 }}>
+    <div className="panel" style={{ marginTop: 16 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-        <div style={{ fontSize: '1.4rem', fontWeight: 700 }}>{prompt}</div>
+        <div style={{ fontSize: '1.4rem', fontWeight: 700, color: 'var(--neon-yellow)' }}>{prompt}</div>
         <button onClick={() => speak(target.hr)} style={buttonBase({ padding: '4px 8px' })}>🔊</button>
       </div>
       <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
@@ -351,7 +364,7 @@ function Quiz({ pool, idx, setIdx, choices, front, speak }) {
           </button>
         ))}
       </div>
-      <div style={{ marginTop: 8, fontSize: 14, color: '#666' }}>Question { (idx % pool.length) + 1 } / {pool.length}</div>
+      <div style={{ marginTop: 8, fontSize: 14, color: 'var(--neon-pink)' }}>Question { (idx % pool.length) + 1 } / {pool.length}</div>
     </div>
   );
 }
@@ -369,8 +382,8 @@ function Manager({ cards, allCards, onDelete, onAdd, onExport, onImport, importE
 
   return (
     <div style={{ marginTop: 16, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
-      <div style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: 16, padding: 16 }}>
-        <h3 style={{ fontWeight: 700, fontSize: 18 }}>Add a phrase</h3>
+      <div className="panel">
+        <h3 style={{ fontWeight: 700, fontSize: 18, color: 'var(--neon-pink)' }}>Add a phrase</h3>
         <form onSubmit={submit} style={{ marginTop: 12, display: 'grid', gap: 8 }}>
           <input style={inp()} placeholder="Croatian (HR)" value={form.hr} onChange={e => setForm({ ...form, hr: e.target.value })} />
           <input style={inp()} placeholder="English (EN)" value={form.en} onChange={e => setForm({ ...form, en: e.target.value })} />
@@ -386,18 +399,18 @@ function Manager({ cards, allCards, onDelete, onAdd, onExport, onImport, importE
               <input type="file" accept="application/json" style={{ display: 'none' }} onChange={onImport} />
             </label>
           </div>
-          {importErr && <div style={{ color: '#b00020', fontSize: 14 }}>{importErr}</div>}
+          {importErr && <div style={{ color: 'var(--neon-pink)', fontSize: 14 }}>{importErr}</div>}
         </form>
       </div>
 
-      <div style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: 16, padding: 16 }}>
-        <h3 style={{ fontWeight: 700, fontSize: 18 }}>Your phrases ({cards.length})</h3>
+      <div className="panel">
+        <h3 style={{ fontWeight: 700, fontSize: 18, color: 'var(--neon-pink)' }}>Your phrases ({cards.length})</h3>
         <ul style={{ marginTop: 12, listStyle: 'none', padding: 0 }}>
           {cards.map(c => (
-            <li key={c.id} style={{ padding: '8px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, borderBottom: '1px solid #f0f0f0' }}>
+            <li key={c.id} style={{ padding: '8px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, borderBottom: '1px solid rgba(0,234,255,0.2)' }}>
               <div>
-                <div style={{ fontWeight: 600 }}>{c.hr} <span style={{ color: '#888' }}>→</span> {c.en}</div>
-                <div style={{ fontSize: 12, color: '#777' }}>{c.cat} • reps {c.srs?.reps ?? 0} • ease {Number(c.srs?.ease || 2.5).toFixed(2)}</div>
+                <div style={{ fontWeight: 600 }}>{c.hr} <span style={{ color: 'var(--neon-yellow)' }}>→</span> {c.en}</div>
+                <div style={{ fontSize: 12, color: 'var(--neon-blue)' }}>{c.cat} • reps {c.srs?.reps ?? 0} • ease {Number(c.srs?.ease || 2.5).toFixed(2)}</div>
               </div>
               <div style={{ display: 'flex', gap: 8 }}>
                 <button style={buttonBase()} onClick={() => speak(c.hr)}>Play</button>
@@ -413,20 +426,16 @@ function Manager({ cards, allCards, onDelete, onAdd, onExport, onImport, importE
 }
 
 function EmptyState({ text }) {
-  return <div style={{ marginTop: 20, padding: 16, border: '2px dashed #eaeaea', borderRadius: 16, textAlign: 'center', background: '#fff', color: '#666' }}>{text}</div>;
+  return <div className="empty">{text}</div>;
 }
 
 // Inline styles/helpers
 function btn(active) {
-  return `px-3 py-2 rounded-lg border ${active ? "bg-black text-white border-black" : "bg-white border-neutral-300 hover:bg-neutral-50"}`;
+  return `btn${active ? " btn-active" : ""}`;
 }
 function buttonBase(extra) {
-  return { padding: '8px 12px', borderRadius: 10, border: '1px solid #ddd', background: '#fff', ...extra };
-}
-function gradeBtn(i) {
-  const base = { padding: '8px 10px', borderRadius: 12, fontSize: 14, border: '1px solid #ddd' };
-  return base;
+  return { padding: '8px 12px', borderRadius: 10, border: '2px solid var(--neon-blue)', background: 'rgba(0,0,0,0.2)', color: 'var(--neon-blue)', ...extra };
 }
 function inp(extra) {
-  return { padding: '8px 12px', borderRadius: 10, border: '1px solid #ddd', background: '#fff', ...extra };
+  return { padding: '8px 12px', borderRadius: 10, border: '2px solid var(--neon-blue)', background: 'rgba(0,0,0,0.2)', color: 'var(--neon-blue)', ...extra };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import { registerSW } from 'virtual:pwa-register'
+import './synthwave.css'
 
 registerSW({
   onNeedRefresh() {},

--- a/src/synthwave.css
+++ b/src/synthwave.css
@@ -1,0 +1,177 @@
+:root {
+  --bg-start: #0a0028;
+  --bg-end: #220052;
+  --neon-pink: #ff00d4;
+  --neon-blue: #00eaff;
+  --neon-yellow: #faff00;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
+  color: var(--neon-blue);
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 14px;
+}
+
+h1, h2, h3 {
+  font-weight: 600;
+  margin: 0;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  position: relative;
+  height: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  text-align: center;
+}
+
+.hero .hero-text {
+  z-index: 2;
+}
+
+.hero h1 {
+  font-size: 2.2rem;
+  color: var(--neon-pink);
+}
+
+.hero p {
+  font-size: 1rem;
+  color: var(--neon-blue);
+}
+
+.hero .sun {
+  position: absolute;
+  top: 20px;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, var(--neon-yellow) 0%, var(--neon-pink) 60%, transparent 70%);
+  box-shadow: 0 0 50px var(--neon-pink);
+  overflow: hidden;
+}
+
+.hero .sun::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(to top, rgba(0,0,0,0.25) 0 4px, transparent 4px 8px);
+}
+
+.hero svg.pyramid {
+  position: absolute;
+  bottom: 80px;
+  width: 160px;
+  height: 120px;
+  fill: none;
+  stroke: var(--neon-blue);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 6px var(--neon-blue));
+}
+
+.hero .grid {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 50%;
+  background:
+    linear-gradient(to right, transparent 0 38px, rgba(0,234,255,0.3) 38px 40px),
+    linear-gradient(to top, transparent 0 38px, rgba(0,234,255,0.3) 38px 40px);
+  background-size: 40px 40px;
+  transform: perspective(200px) rotateX(60deg);
+  transform-origin: top;
+  filter: drop-shadow(0 0 6px var(--neon-blue));
+}
+
+.nav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
+}
+
+.btn {
+  background: transparent;
+  border: 2px solid var(--neon-blue);
+  color: var(--neon-blue);
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s;
+}
+
+.btn:hover {
+  border-color: var(--neon-pink);
+  color: var(--neon-pink);
+  box-shadow: 0 0 6px var(--neon-pink);
+}
+
+.btn-active {
+  background: var(--neon-blue);
+  color: #000;
+}
+
+input, select {
+  background: rgba(0,0,0,0.2);
+  border: 2px solid var(--neon-blue);
+  color: var(--neon-blue);
+  border-radius: 8px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+input::placeholder {
+  color: var(--neon-pink);
+}
+
+.panel {
+  background: rgba(0,0,0,0.3);
+  border: 2px solid var(--neon-blue);
+  border-radius: 16px;
+  padding: 16px;
+  color: var(--neon-blue);
+}
+
+.empty {
+  margin-top: 20px;
+  padding: 16px;
+  border: 2px dashed var(--neon-pink);
+  border-radius: 16px;
+  text-align: center;
+  background: rgba(0,0,0,0.2);
+  color: var(--neon-blue);
+}
+
+.divider {
+  border: none;
+  height: 3px;
+  background: var(--neon-pink);
+  margin: 1rem 0;
+}
+
+.grade-btn {
+  border: 2px solid var(--neon-blue);
+  background: rgba(0,0,0,0.2);
+  color: var(--neon-blue);
+  border-radius: 12px;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+}
+


### PR DESCRIPTION
## Summary
- add neon synthwave CSS theme with gradient background and hero graphics
- overhaul app layout with neon buttons, grid dividers, and retro hero section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689677fe8c0083328737362209068cb7