### PR TITLE
Remove quiz mode, enable audio on click, and add Open Graph metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Croatian Phrase Coach (PWA)
 
 A minimal React + Vite Progressive Web App for learning Croatian phrases.
-- Flashcards + Quiz
+- Flashcards
 - Spaced repetition (SM-2-lite)
 - Text-to-speech (browser voices)
 - Offline-ready via service worker

--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#0a0028" />
+    <meta name="description" content="Study Croatian phrases with audio flashcards." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Croatian Phrase Coach" />
+    <meta property="og:description" content="Interactive PWA to learn Croatian phrases with audio playback." />
+    <meta property="og:image" content="/pwa-512x512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Croatian Phrase Coach" />
+    <meta name="twitter:description" content="Interactive PWA to learn Croatian phrases with audio playback." />
+    <meta name="twitter:image" content="/pwa-512x512.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;600&display=swap" rel="stylesheet" />

--- a/src/synthwave.css
+++ b/src/synthwave.css
@@ -40,8 +40,10 @@ h1, h2, h3 {
 }
 
 .hero h1 {
-  font-size: 2.2rem;
+  font-size: 2.8rem;
   color: var(--neon-pink);
+  font-weight: 700;
+  text-shadow: 2px 2px 4px #000;
 }
 
 .hero p {


### PR DESCRIPTION
## Summary
- Improve hero header legibility with larger text and shadow
- Play Croatian audio whenever phrases are clicked in study and manage views
- Remove quiz mode and related UI
- Add SEO metadata using existing PWA icon for Open Graph/Twitter image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689685a285e483328da99198f25c8f72