### PR TITLE
Restore quiz mode, enable audio on click, and add Open Graph metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#0a0028" />
+    <meta name="description" content="Study Croatian phrases with audio flashcards." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Croatian Phrase Coach" />
+    <meta property="og:description" content="Interactive PWA to learn Croatian phrases with audio playback." />
+    <meta property="og:image" content="/pwa-512x512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Croatian Phrase Coach" />
+    <meta name="twitter:description" content="Interactive PWA to learn Croatian phrases with audio playback." />
+    <meta name="twitter:image" content="/pwa-512x512.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;600&display=swap" rel="stylesheet" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,11 +105,11 @@ const SEED = [
 
 function useCroatianVoice() {
   const [voices, setVoices] = useState([]);
-  const croatian = React.useMemo(() => {
+  const croatian = useMemo(() => {
     return voices.find(v => /hr|croatian/i.test(`${v.lang} ${v.name}`)) || voices[0];
   }, [voices]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const load = () => setVoices(window.speechSynthesis?.getVoices?.() || []);
     load();
     const id = setInterval(load, 500);
@@ -133,24 +133,23 @@ function useCroatianVoice() {
 export default function App() {
   const [cards, setCards] = useState(() => loadState()?.cards ?? seedWithSRS(SEED));
   const [mode, setMode] = useState("flashcards"); // flashcards | quiz | manage
+  const [quizIdx, setQuizIdx] = useState(0);
   const [query, setQuery] = useState("");
   const [cat, setCat] = useState("All");
   const [front, setFront] = useState("hr"); // which side is front
-  const [quizIdx, setQuizIdx] = useState(0);
   const [importErr, setImportErr] = useState("");
   const { speak } = useCroatianVoice();
 
-  React.useEffect(() => saveState({ cards }), [cards]);
+  useEffect(() => saveState({ cards }), [cards]);
 
-  const cats = React.useMemo(() => ["All", ...Array.from(new Set(cards.map(c => c.cat)))], [cards]);
-  const dueCount = React.useMemo(() => cards.filter(c => (c.srs?.due ?? 0) <= now()).length, [cards]);
+  const cats = useMemo(() => ["All", ...Array.from(new Set(cards.map(c => c.cat)))], [cards]);
 
-  const filtered = React.useMemo(() => {
+  const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return cards.filter(c => (cat === "All" || c.cat === cat) && (!q || `${c.hr} ${c.en}`.toLowerCase().includes(q)));
   }, [cards, cat, query]);
 
-  const nextDue = React.useMemo(() => filtered.find(c => (c.srs?.due ?? 0) <= now()) || filtered[0], [filtered]);
+  const nextDue = useMemo(() => filtered.find(c => (c.srs?.due ?? 0) <= now()) || filtered[0], [filtered]);
 
 
   function seedWithSRS(list) {
@@ -289,6 +288,7 @@ function FlashcardStudy({ card, pool, front, onGrade, speak }) {
   }, [card, pool]);
 
   function pick(c) {
+    speak(c.hr);
     const correct = front === "hr" ? c.en === card.en : c.hr === card.hr;
     onGrade(correct ? 5 : 1);
   }
@@ -298,9 +298,12 @@ function FlashcardStudy({ card, pool, front, onGrade, speak }) {
       <div className="panel">
         <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-
-            <div style={{ fontSize: '1.6rem', fontWeight: 700, lineHeight: 1.2, color: 'var(--neon-yellow)' }}>{prompt}</div>
-            <button onClick={() => speak(card.hr)} style={buttonBase({ padding: '4px 8px' })}>🔊</button>
+            <div
+              style={{ fontSize: '1.6rem', fontWeight: 700, lineHeight: 1.2, color: 'var(--neon-yellow)', cursor: 'pointer' }}
+              onClick={() => speak(card.hr)}
+            >
+              {prompt}
+            </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={{ fontSize: 12, color: 'var(--neon-pink)' }}>{card.cat}</span>
@@ -315,10 +318,9 @@ function FlashcardStudy({ card, pool, front, onGrade, speak }) {
             <button
               key={c.id}
               onClick={() => pick(c)}
-              style={buttonBase({ textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' })}
+              style={buttonBase({ textAlign: 'center' })}
             >
-              <span>{front === "hr" ? c.en : c.hr}</span>
-              <span onClick={(e) => { e.stopPropagation(); speak(c.hr); }}>🔊</span>
+              {front === "hr" ? c.en : c.hr}
             </button>
           ))}
         </div>
@@ -331,44 +333,48 @@ function Quiz({ pool, idx, setIdx, front, speak }) {
   if (!pool.length) return <EmptyState text="No cards to quiz."/>;
   const target = pool[idx % pool.length];
   const prompt = front === "hr" ? target.hr : target.en;
-  const correct = front === "hr" ? target.en : target.hr;
-
-  function pick(choice) {
-    const isRight = (front === "hr" ? choice.en === correct : choice.hr === correct);
-    setTimeout(() => setIdx(idx + 1), 300);
-  }
 
   const opts = useMemo(() => {
     const others = pool.filter(c => c.id !== target.id).sort(() => Math.random() - 0.5).slice(0, 3);
     return [...others, target].sort(() => Math.random() - 0.5);
   }, [target, pool]);
 
+  function pick(c) {
+    speak(c.hr);
+    setTimeout(() => setIdx(idx + 1), 300);
+  }
+
   return (
     <div className="panel" style={{ marginTop: 16 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-        <div style={{ fontSize: '1.4rem', fontWeight: 700, color: 'var(--neon-yellow)' }}>{prompt}</div>
-        <button onClick={() => speak(target.hr)} style={buttonBase({ padding: '4px 8px' })}>🔊</button>
+        <div
+          onClick={() => speak(target.hr)}
+          style={{ fontSize: '1.4rem', fontWeight: 700, color: 'var(--neon-yellow)', cursor: 'pointer' }}
+        >
+          {prompt}
+        </div>
       </div>
       <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
         {opts.map(c => (
           <button
             key={c.id}
             onClick={() => pick(c)}
-            style={buttonBase({ textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' })}
+            style={buttonBase({ textAlign: 'center' })}
           >
-            <span>{front === "hr" ? c.en : c.hr}</span>
-            <span onClick={(e) => { e.stopPropagation(); speak(c.hr); }}>🔊</span>
+            {front === "hr" ? c.en : c.hr}
           </button>
         ))}
       </div>
-      <div style={{ marginTop: 8, fontSize: 14, color: 'var(--neon-pink)' }}>Question { (idx % pool.length) + 1 } / {pool.length}</div>
+      <div style={{ marginTop: 8, fontSize: 14, color: 'var(--neon-pink)' }}>
+        Question {(idx % pool.length) + 1} / {pool.length}
+      </div>
     </div>
   );
 }
 
 function Manager({ cards, allCards, onDelete, onAdd, onExport, onImport, importErr, speak }) {
   const [form, setForm] = useState({ hr: "", en: "", cat: "Custom", note: "" });
-  const cats = React.useMemo(() => Array.from(new Set(allCards.map(c => c.cat))), [allCards]);
+  const cats = useMemo(() => Array.from(new Set(allCards.map(c => c.cat))), [allCards]);
 
   function submit(e) {
     e.preventDefault();
@@ -405,12 +411,11 @@ function Manager({ cards, allCards, onDelete, onAdd, onExport, onImport, importE
         <ul style={{ marginTop: 12, listStyle: 'none', padding: 0 }}>
           {cards.map(c => (
             <li key={c.id} style={{ padding: '8px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, borderBottom: '1px solid rgba(0,234,255,0.2)' }}>
-              <div>
+              <div onClick={() => speak(c.hr)} style={{ cursor: 'pointer' }}>
                 <div style={{ fontWeight: 600 }}>{c.hr} <span style={{ color: 'var(--neon-yellow)' }}>→</span> {c.en}</div>
                 <div style={{ fontSize: 12, color: 'var(--neon-blue)' }}>{c.cat} • reps {c.srs?.reps ?? 0} • ease {Number(c.srs?.ease || 2.5).toFixed(2)}</div>
               </div>
               <div style={{ display: 'flex', gap: 8 }}>
-                <button style={buttonBase()} onClick={() => speak(c.hr)}>Play</button>
                 <button style={buttonBase()} onClick={() => navigator?.clipboard?.writeText(`${c.hr} — ${c.en}`)}>Copy</button>
                 <button style={buttonBase()} onClick={() => onDelete(c.id)}>Delete</button>
               </div>

--- a/src/synthwave.css
+++ b/src/synthwave.css
@@ -40,8 +40,10 @@ h1, h2, h3 {
 }
 
 .hero h1 {
-  font-size: 2.2rem;
+  font-size: 2.8rem;
   color: var(--neon-pink);
+  font-weight: 700;
+  text-shadow: 2px 2px 4px #000;
 }
 
 .hero p {


### PR DESCRIPTION
## Summary
- Improve hero header legibility with larger text and shadow
- Play Croatian audio whenever phrases are clicked in study, quiz, and manage views
- Restore quiz mode and related UI
- Add SEO metadata using existing PWA icon for Open Graph/Twitter image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Dynamic require of "workbox-build" is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689685a285e483328da99198f25c8f72